### PR TITLE
Use release builds

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DJSON_BuildTests=OFF ..
-          cmake --build .
+          cmake --build . --config Release
           sudo cmake --install .
           cd ..
 
@@ -47,7 +47,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DCMAKE_BUILD_TYPE=Release ..
-          cmake --build .
+          cmake --build . --config Release
           cd ..
 
       # now we can deploy the release if necessary

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DJSON_BuildTests=OFF ..
-          cmake --build .
+          cmake --build . --config Release
           cmake --install .
           cd ..
 
@@ -47,7 +47,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DCMAKE_BUILD_TYPE=Release ..
-          cmake --build .
+          cmake --build . --config Release
           cd ..
 
       # If Apple didn't insist on bundling apps as folders, this wouldn't be necessary; however, this is done to ensure that the .app folder remains intact

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DJSON_BuildTests=OFF ..
-          cmake --build .
+          cmake --build . --config Release
           cmake --install .
           cd ..
 
@@ -47,7 +47,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DCMAKE_BUILD_TYPE=Release ..
-          cmake --build .
+          cmake --build . --config Release
           cd ..
 
       - name: Upload binary


### PR DESCRIPTION
This has a twofold purpose. One, it switches from MinSizeRel builds to Release builds, because why optimize an already tiny binary for space? Two, it actually makes all builds build with Release configuration: Windows CMake, for some reason, requires the flag `--config Release` to actually trigger a Release build.